### PR TITLE
ensure fallback for power names with suffixes in lookupItems

### DIFF
--- a/esmodules/tools/cbuilder_xml_import.js
+++ b/esmodules/tools/cbuilder_xml_import.js
@@ -784,11 +784,18 @@ async function lookupItems(compendium, names, nameLookup, matchType = "partial",
                         const pattern = new RegExp("^" + target.replaceAll(/[\(\)\[\]\+]/g, "\\$&"), "i");
                         entry = compendium.index.filter(x => x.name.match(pattern)); // Array
                     } else if (matchType === "no_parentheses") {
-                        const pattern = target.replace(/\(.*\)/, "").trim();
+                        const pattern = typeof target === "string" ? target.replace(/\(.*\)/, "").trim() : target;
                         entry = compendium.index.find(x => x.name === pattern);
                     } else if (matchType === "pattern") {
                         entry = compendium.index.filter(x => x.name.match(target)).sort(itemSortOrderShortFirst)[0];
                     }
+                }
+
+                // Fallback: Try normalized name
+                if (!entry && typeof target === "string") {
+                    const normalizedTarget = target.replace(/\s*\(.*?\)$/, "").trim();
+                    const pattern = new RegExp(normalizedTarget.replaceAll(/[\(\)\[\]\+]/g, "\\$&"), "i");
+                    entry = compendium.index.filter(x => x.name.match(pattern)).sort(itemSortOrderShortFirst)[0];
                 }
 
                 if (entry && Object.keys(entry).length > 0) {
@@ -816,6 +823,10 @@ async function lookupItems(compendium, names, nameLookup, matchType = "partial",
 
     return items;
 }
+
+
+
+
 
 // Rename an item
 function renameItem(item, name) {


### PR DESCRIPTION
add fallback logic to normalize power names by removing parenthetical suffixes (e.g., "Clever Shot (Archery Mastery)") when exact matches fail.

verify input types before applying string operations