### PR TITLE
fix import of loot entries with count ≠ 1

### DIFF
--- a/esmodules/tools/cbuilder_xml_import.js
+++ b/esmodules/tools/cbuilder_xml_import.js
@@ -509,7 +509,11 @@ function getLoot(doc) {
     const elements = [];
 
     doc.querySelectorAll("LootTally > loot").forEach(
-        x => elements.push(getLootComponents(x))
+        x => {
+            if (x.getAttribute("count") === "1") {
+                elements.push(getLootComponents(x))
+            }
+        }
     );
 
     return elements;


### PR DESCRIPTION
CB keeps a tally of every item ever added. This prevents importing loot items that have been removed.