### PR TITLE
fix: guard parseMoney against empty/malformed currency strings

### DIFF
--- a/esmodules/tools/cbuilder_xml_import.js
+++ b/esmodules/tools/cbuilder_xml_import.js
@@ -908,11 +908,15 @@ async function setSkills(actor, skills) {
 // Read currency values
 function parseMoney(str, wealth = null) {
     const currencies = wealth ?? { "ad": 0, "pp": 0, "gp": 0, "sp": 0, "cp": 0 };
+    if (!str || !str.trim()) return currencies;
+
     const currencyArray = str.replaceAll(",", "").split(";");
 
     for (const x of currencyArray) {
         const currency = x.trim().split(" ");
-        currencies[currency[1]] += Number(currency[0]);
+        if (currency.length >= 2 && currency[1]) {
+            currencies[currency[1]] += Number(currency[0]);
+        }
     }
 
     return currencies;


### PR DESCRIPTION
## Problem

Characters who carry no stored wealth have an empty `StoredMoney` field in their `.dnd4e` XML file. When such a character is imported, the following validation error is thrown and the import fails:

```
DataModelValidationError: Actor4e [...] validation errors:
  system: currency: undefined: must be an integer
```

This does **not** affect every character — only those with a blank `StoredMoney` value.

## Root cause

`parseMoney()` had two bugs:

1. It called `str.replaceAll()` unconditionally, which throws when `str` is `null` or an empty string.
2. When a currency token contained no space (e.g. a trailing semicolon producing `""`), `currency[1]` was `undefined`. This wrote `currencies[undefined] = NaN` into the currency object, which failed Foundry's integer validation.

## Fix

- Return early if the input string is empty or whitespace-only.
- Skip any token that does not have both an amount and a denomination part.

## Testing

Reproduced with a character whose `StoredMoney` field is `""`. After this fix the import completes without error and currency values are correct.

Made with [Cursor](https://cursor.com)